### PR TITLE
Add ability for Selleck to use a custom Handlebars object

### DIFF
--- a/bin/selleck
+++ b/bin/selleck
@@ -76,6 +76,8 @@ var fs        = require('fs'),
         "                         instead of the default (.html).",
         "  --out-meta <filename>  Write combined project and component JSON metadata to",
         "                         the specified filename.",
+        "  --handlebars <file>    Path to a JS file that exports a Handlebars object which will",
+        "                         override the default implementation used by Selleck",
         ""
     ].join('\n');
 
@@ -128,6 +130,10 @@ while ((arg = argv.shift())) {
     case '--out-metadata':
     case '--out-meta':
         options['out-meta'] = argv.shift();
+        break;
+
+    case '--handlebars':
+        options.handlebars = argv.shift();
         break;
 
     case '--project':
@@ -198,6 +204,7 @@ if (options.server) {
     theme.partials = selleck.getPartials(options.theme);
 
     // Traverse the root path and look for documentation directories.
+    selleck.useCustomHandlebars(options.handlebars);
     docs = selleck.findDocs(options.rootPath, docs);
 
     if (docs.project) {

--- a/lib/selleck.js
+++ b/lib/selleck.js
@@ -439,6 +439,22 @@ function prepare(inDir, options, callback) {
 exports.prepare = prepare;
 
 /**
+ * @method useCustomHandlebars
+ * @param filePath the file path to use to `require` a custom Handlebars object instead of the default. May be falsy
+ *  in which case it is ignored. This allows you to use, for example, a Handlebars module that has been pre-registered
+ *  with your custom helpers.
+ */
+function useCustomHandlebars(filePath) {
+    if (filePath) {
+        filePath = path.resolve(filePath);
+        log('Using handlebars from: ' + filePath);
+        Handlebars = require(filePath);
+    }
+}
+
+exports.useCustomHandlebars = useCustomHandlebars;
+
+/**
 Renders the specified template source.
 
 @method render

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,6 +18,7 @@ module.exports = function (config) {
         stack      = new util.Stack(),
         projectPath;
 
+    selleck.useCustomHandlebars(config.handlebars);
     docs        = selleck.findDocs(config.rootPath, docs);
     projectPath = docs.project && docs.project.path;
 


### PR DESCRIPTION
This is take 2 of my original pull request that allowed for handlebars helpers to be tacked on to the Handlebars object.

https://github.com/yui/selleck/pull/9

There were multiple problems with that approach, mostly because the Handlebars object is global and cannot be overridden per-component, the semantics of loading a custom config that could itself require dependencies was hairy and so on.

This PR inverts the model and allows the user to pass in `--handlebars <path>` option. `path` is then `require`-ed in selleck and used to update the `Handlebars` object in place, early before any rendering is done.

Thus, as long as the module provides an object that is compatible to Handlebars, it will work seamlessly and the user now has the option to associate all sorts of helpers applied at a "system" level.

The advantages of this approach are:
- Selleck no longer has to deal with custom config etc. but uses a replacement handlebars instead.
- The user can go crazy with handlebars helpers in terms of have a custom module with all sorts of dependencies for the helpers without having to make those dependencies known to selleck. In a sample that I'm currently using I use handlebars helpers for JSON rendering, markdown to HTML transformation etc. My custom module encapsulates all this logic (using node-markdown dependencies etc.) without touching selleck in any way.

There is now an implicit coupling between the markup in the docs and the helpers needed to render them but this is treated as user problem and not a selleck problem.

If you guys like this approach, I will move forward and add tests and such otherwise I'll just keep building my docs out of my fork :)
