### PR TITLE
Added ability to have deep partials. Now supports {{>sub-dir/partial}}.

### DIFF
--- a/lib/selleck.js
+++ b/lib/selleck.js
@@ -249,28 +249,44 @@ preceding the .mustache extension) to page content.
 
 @method getPages
 @param {String} dir Directory path.
+@param {Boolean} [deep] If true, will return all pages in subdirectories as well.
 @return {Object} Mapping of page names to page content.
 **/
-function getPages(dir) {
+function getPages(dir, deep) {
     var pages = {};
 
-    if (!fileutils.isDirectory(dir, true)) { return pages; }
+    function loopDirAndGetMustaches(dir, pages, depthDir) {
 
-    fs.readdirSync(dir).forEach(function (filename) {
-        var filePath = path.join(dir, filename);
-
-        if (path.extname(filename) === '.mustache' && fileutils.isFile(filePath)) {
-            pages[path.basename(filename, '.mustache')] = fs.readFileSync(filePath, 'utf8');
+        if (depthDir) {
+            depthDir += '/';
+        } else {
+            depthDir = '';
         }
-    });
+
+        if (!fileutils.isDirectory(dir, true)) { return pages; }
+
+        fs.readdirSync(dir).forEach(function (filename) {
+            var filePath = path.join(dir, filename);
+
+            if (deep && fileutils.isDirectory(filePath)) {
+                loopDirAndGetMustaches(filePath, pages, depthDir + filename);
+            } else {
+                if (path.extname(filename) === '.mustache' && fileutils.isFile(filePath)) {
+                    pages[depthDir + path.basename(filename, '.mustache')] = fs.readFileSync(filePath, 'utf8');
+                }
+            }
+
+        });
+    }
+
+    loopDirAndGetMustaches(dir, pages);
 
     return pages;
-}
-exports.getPages = getPages;
+}exports.getPages = getPages;
 
 /**
-Like `getPages()`, but returns only the files under the `partial/` subdirectory
-of the specified _dir_.
+Like `getPages()`, but returns only the files under the `partial/` subdirectory,
+as well as it's subdirectories, of the specified _dir_.
 
 @method getPartials
 @param {String} dir Directory path.
@@ -278,7 +294,7 @@ of the specified _dir_.
 **/
 function getPartials(dir) {
     dir = dir || '';
-    return getPages(path.join(dir, 'partials'));
+    return getPages(path.join(dir, 'partials'), true);
 }
 exports.getPartials = getPartials;
 


### PR DESCRIPTION
Added ability to have subdirectories of partials.

Now docs can have a tree of:
docs -
- partials
  - exampleA
    - a-full.mustache
    - a-markup.mustache
    - a-style.mustache
  - exampleB
    - b-full.mustache
    - b-markup.mustache
    - b-style.mustache

You would use exampleA's full mustache partial with {{>exampleA/a-full}}

This promotes a more modular approach to partials and example support files.
