### PR TITLE
add top-level npm-debug.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/node_modules/
 **/npm-debug.log
 node_modules/
+npm-debug.log
 tmp/
 CVS/
 .DS_Store


### PR DESCRIPTION
as it wasn't being picked up with the current '**/npm-debug.log' rule
