### PR TITLE
Fix a typo in the command line usage section

### DIFF
--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -387,7 +387,7 @@ After installation, you'll have a new command line application named <kbd>sellec
 </p>
 
 <p>
-If no options are given, Selleck will search the current directory and all its subdirectories recursively, looking for documentation directories (it does this by searching for <samp>project.json</samp> and <samp>component.json</samp> files). It will generate HTML documentation from all the doc directories it finds, and will write the generated docs to <samp>./docs</samp> by default.
+If no options are given, Selleck will search the current directory and all its subdirectories recursively, looking for documentation directories (it does this by searching for <samp>project.json</samp> and <samp>component.json</samp> files). It will generate HTML documentation from all the <code>docs</code> directories it finds, and will write the generated docs to <samp>./docs</samp> by default.
 </p>
 
 <pre class="code terminal"><span class="noselect">$ </span>cd ~&#x2F;src&#x2F;yui&#x2F;yui3

--- a/docs/raw/index.mustache
+++ b/docs/raw/index.mustache
@@ -374,7 +374,7 @@ After installation, you'll have a new command line application named <kbd>sellec
 </p>
 
 <p>
-If no options are given, Selleck will search the current directory and all its subdirectories recursively, looking for documentation directories (it does this by searching for <samp>project.json</samp> and <samp>component.json</samp> files). It will generate HTML documentation from all the doc directories it finds, and will write the generated docs to <samp>./docs</samp> by default.
+If no options are given, Selleck will search the current directory and all its subdirectories recursively, looking for documentation directories (it does this by searching for <samp>project.json</samp> and <samp>component.json</samp> files). It will generate HTML documentation from all the `docs` directories it finds, and will write the generated docs to <samp>./docs</samp> by default.
 </p>
 
 ```terminal


### PR DESCRIPTION
Current doc says: _[...]It will generate HTML documentation from all the doc directories it finds[...]_

But in the example we see **docs** (not 'doc') :P

```
$ cd ~/src/yui/yui3
$ selleck
[info] Generating project docs for /Users/rgrove/src/yui/yui3/src/common/docs
[info] Generating component docs for /Users/rgrove/src/yui/yui3/src/autocomplete/docs
[info] Generating component docs for /Users/rgrove/src/yui/yui3/src/history/docs
[info] Done! Docs were written to: ./docs
```

Does it matter though? Or does Selleck look for both (docs and doc)?
